### PR TITLE
Improve mobile layout and add accessibility focus states

### DIFF
--- a/src/components/UrlInput.tsx
+++ b/src/components/UrlInput.tsx
@@ -37,10 +37,10 @@ export default function UrlInput({ onClean }: Props) {
 
   return (
     <div className="flex flex-col w-full gap-1">
-      <div className="flex gap-2 w-full">
+      <div className="flex gap-2 w-full flex-col sm:flex-row">
         <input
           type="text"
-          className="flex-1 border rounded px-3 py-2 dark:bg-gray-800 dark:text-white"
+          className="flex-1 border rounded px-3 py-2 dark:bg-gray-800 dark:text-white transition-colors hover:border-gray-400 dark:hover:border-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
           value={value}
           onChange={(e) => {
             setValue(e.target.value);
@@ -52,7 +52,7 @@ export default function UrlInput({ onClean }: Props) {
           placeholder="Pega tu URL"
         />
         <button
-          className="bg-blue-600 text-white px-4 py-2 rounded"
+          className="bg-blue-600 text-white px-4 py-2 rounded transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 w-full sm:w-auto disabled:opacity-50"
           onClick={handleClean}
           disabled={disabled}
         >

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,6 +13,10 @@ import App from '../components/App';
   </head>
   <body class="h-full bg-gray-50 dark:bg-gray-900 dark:text-white">
     <div id="app" class="max-w-xl mx-auto p-4">
+      <h1 class="text-3xl font-bold text-center mb-2">Limpiador de URLs</h1>
+      <p class="text-lg text-center mb-4 text-gray-700 dark:text-gray-300">
+        Pega un enlace y elimina parámetros de seguimiento
+      </p>
       <App client:load />
     </div>
   </body>


### PR DESCRIPTION
## Summary
- add page heading and instructions
- stack input/button on small screens and add focus states

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849dbbbb9808332a51be9076c5d6e63