### PR TITLE
Implement manual dark mode toggle

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'dark') {
+      setTheme('dark');
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  function toggle() {
+    setTheme(theme === 'dark' ? 'light' : 'dark');
+  }
+
+  return (
+    <button
+      className="absolute top-2 right-2 text-sm bg-gray-200 dark:bg-gray-700 px-3 py-1 rounded"
+      onClick={toggle}
+    >
+      {theme === 'dark' ? 'Modo claro 💡' : 'Modo oscuro 🌙'}
+    </button>
+  );
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import App from '../components/App';
+import ThemeToggle from '../components/ThemeToggle';
 ---
 <html lang="es" class="h-full">
   <head>
@@ -10,9 +11,16 @@ import App from '../components/App';
     <meta property="og:title" content="link-cleaner" />
     <meta property="og:description" content="Limpia tus URLs de parametros de seguimiento" />
     <meta property="og:type" content="website" />
+    <script>
+      const stored = localStorage.getItem('theme');
+      if (stored === 'dark') {
+        document.documentElement.classList.add('dark');
+      }
+    </script>
   </head>
   <body class="h-full bg-gray-50 dark:bg-gray-900 dark:text-white">
     <div id="app" class="max-w-xl mx-auto p-4">
+      <ThemeToggle client:load />
       <App client:load />
     </div>
   </body>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  darkMode: 'class',
+  content: ['./src/**/*.{astro,html,js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- configure Tailwind to use `darkMode: 'class'`
- add `ThemeToggle` component
- load user's theme preference on page load and render toggle

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849dbc515c48332a11bf330d607764c