### PR TITLE
Add ThemeToggle to index page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,6 +25,7 @@ import '../styles/global.css';
       <p class="text-lg text-center mb-4 text-gray-700 dark:text-gray-300">
         Pega un enlace y elimina parámetros de seguimiento
       </p>
+      <ThemeToggle client:load />
       <App client:load />
     </div>
   </body>


### PR DESCRIPTION
## Summary
- render the ThemeToggle component on the homepage

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849e33e0fd0833288b794febba14a58